### PR TITLE
Add her parser for handling json and camel casing keys

### DIFF
--- a/lib/her/middleware.rb
+++ b/lib/her/middleware.rb
@@ -6,5 +6,7 @@ require "her/middleware/accept_json"
 module Her
   module Middleware
     DefaultParseJSON = FirstLevelParseJSON
+
+    autoload :SnakeCaseParser, 'her/middleware/snake_case_parser'
   end
 end

--- a/lib/her/middleware/snake_case_parser.rb
+++ b/lib/her/middleware/snake_case_parser.rb
@@ -5,7 +5,7 @@ module Her
       def snake_caseify(val)
         case val
         when Array
-          val.map { |v| call(v) }
+          val.map { |v| snake_caseify(v) }
         when Hash
           val.deep_transform_keys { |k| k.to_s.underscore }
         else

--- a/lib/her/middleware/snake_case_parser.rb
+++ b/lib/her/middleware/snake_case_parser.rb
@@ -1,0 +1,29 @@
+module Her
+  module Middleware
+    class SnakeCaseParser < Faraday::Response::Middleware
+
+      def snake_caseify(val)
+        case val
+        when Array
+          val.map { |v| call(v) }
+        when Hash
+          val.deep_transform_keys { |k| k.to_s.underscore }
+        else
+          val
+        end
+      end
+
+      def on_complete(env)
+        json = snake_caseify(MultiJson.load(env[:body]))
+
+        errors = json.delete('errors') || {}
+        metadata = json.delete('metadata') || {}
+        env[:body] = {
+          data: json,
+          errors: errors,
+          metadata: metadata
+        }
+      end
+    end
+  end
+end

--- a/spec/middleware/snake_case_parser_spec.rb
+++ b/spec/middleware/snake_case_parser_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe Her::Middleware::SnakeCaseParser do
+  subject { described_class.new }
+
+  context "with valid JSON body" do
+    let(:body) { "{\"root\": {\"fooBar\": 1}, \"errors\": 2, \"metadata\": 3}" }
+
+    it "parses :body key as json in the env hash" do
+      env = { :body => body }
+      subject.on_complete(env)
+      env[:body].tap do |json|
+        json[:data].should == { 'root' => { 'foo_bar' => 1 } }
+        json[:errors].should == 2
+        json[:metadata].should == 3
+      end
+    end
+  end
+end


### PR DESCRIPTION
this is more or less our de facto standard now so i think it makes sense to put this in the base for our client gems.

i came across this because the phr_services_client has a load order issue if sesheta is loaded into the same gem. this is because they both use something called snake_case_parser as their response_middleware but don't namespace the class, which cause conflicts.